### PR TITLE
SDK Constraints error fix

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,10 @@
 name: nested_navigation_demo_flutter
 description: A new Flutter project.
 
+
+environment:
+  sdk: '>=2.10.0 <3.0.0'
+
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
```dart
pubspec.yaml has no lower-bound SDK constraint.
You should edit pubspec.yaml to contain an SDK constraint:

environment:
  sdk: '>=2.10.0 <3.0.0'
```

https://dart.dev/tools/pub/pubspec#sdk-constraints